### PR TITLE
fix/extension-filter

### DIFF
--- a/pkg/cmd/resolve.go
+++ b/pkg/cmd/resolve.go
@@ -68,9 +68,8 @@ func resolveFilenamesForPatterns(path string, recursive bool) ([]string, error) 
 				return nil, fmt.Errorf("error walking directory: %w", err)
 			}
 		} else {
-			if !ignoreFile(filepath.Clean(path), FileExtensions) {
-				results = append(results, filepath.Clean(path))
-			}
+			// Only apply the extension filter to files in directories; ignore it for directly specified files.
+			results = append(results, filepath.Clean(path))
 		}
 	}
 

--- a/pkg/cmd/resolve_test.go
+++ b/pkg/cmd/resolve_test.go
@@ -54,13 +54,6 @@ func TestResolveFilenames2(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "Single file invalid extension",
-			path:        testFile1,
-			recursive:   false,
-			expected:    nil,
-			expectError: false,
-		},
-		{
 			name:        "Glob pattern valid extensions",
 			path:        filepath.Join(tempDir, "*.yaml"),
 			recursive:   false,
@@ -224,10 +217,10 @@ func TestResolveAllFiles(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "Ignore unsupported file extension",
+			name:      "If file passed explicitly, don't check its extension",
 			filenames: []string{file3},
 			recursive: false,
-			want:      []string{},
+			want:      []string{file3},
 			wantErr:   false,
 		},
 		{


### PR DESCRIPTION
Only apply the extension filter to files in directories; ignore it for directly specified files.